### PR TITLE
Update README with building image instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ There are currently two variants to build OpenWrt:
 Both variants require differnet configuration files in this repository. The configuration files are stored in a subfolder of the device specific folder. The device specific folders name is the device name and stored in the root directory of this repository.
 
 ### Building development images
-Building development images is used for devices which are not yet supported in OpenWrt but supported in a branch of https://github.com/RolandoMagico/openwrt. The build is intended to be used to provide development images during the process of adding support for a new device in OpenWrt. The requires configuration files in a subfolder of the device specific folder. The folder name must match the origin of the OpenWrt branch the build is based on. Usually it's the ```main``` branch.
+Building development images is used for devices which are not yet supported in OpenWrt but supported in a branch of https://github.com/RolandoMagico/openwrt. The build is intended to be used to provide development images during the process of adding support for a new device in OpenWrt. 
+
+The required configuration files must be stored in a subfolder of the device specific folder. The folder name must match the origin of the OpenWrt branch the build is based on. Usually it's the ```main``` branch.
 
 Two configuration files are needed:
 - ```device.settings``` contains device specific branch and file names for the build
@@ -30,4 +32,21 @@ OPENWRT_TARGET_PROFILE=filogic-dlink_aquila-pro-ai-e30-a1
 
 The target profile name is used to determine the name of all artifacts which are uploaded at the end of the pipeline run.
 
+### Building release images
+Building release images is used for devices which are not yet supported in OpenWrt but patches for a specific OpenWrt version are available to get the deivce supported. The build is intended to be used to provide the same state as OpenWrt released images for the device.
 
+The required configuration files must be stored in a subfolder of the device specific folder. The folder name must match the related OpenWrt version, for example ```24.10.4``` or ```25.12.3```.
+
+Two configuration files are needed:
+- ```device.patch``` contains the all Git patches which are required to add support for the device to the specific OpenWrt version.
+- ```device.settings``` contains device specific branch and file names for the build.
+
+#### Example
+The following ```device.settings``` file is used to build images for the Linksys MR9000 using the OpenWrt tag v25.12.3:
+
+```
+OPENWRT_RELEASE_DIRECTORY=25.12.3
+OPENWRT_TARGET_DIRECTORY=ipq40xx/generic
+OPENWRT_TARGET_PROFILE=linksys_mr9000
+OPENWRT_GIT_BRANCH=v25.12.3
+```


### PR DESCRIPTION
Clarify requirements for building development and release images, including configuration file storage and examples.